### PR TITLE
Add coveralls in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ pytz==2019.3
 requests==2.22.0
 sqlparse==0.3.0
 urllib3==1.25.7
+coveralls==1.8.2


### PR DESCRIPTION
coveralls를 보니 계속 프론트에 대해서만 coverage를 체크하고 있어서 확인해보니
Travis CI에서는 backend coverage를 체크하는데 체크 후에 coveralls 명령어 실행시
`The program 'coveralls' is currently not installed. To run 'coveralls' please ask your administrator to install the package 'ruby-coveralls'`
라고 뜨면서 backend coverage 결과를 coveralls에서 수집하고 있지 않더라구요.
확인해보니 coveralls가 어느순간 requirements.txt에서 지워져 있어서 다시 추가합니다.