### PR TITLE
[Frontend] Create Travel Error Message

### DIFF
--- a/frontend/src/store/actions/travel.js
+++ b/frontend/src/store/actions/travel.js
@@ -183,6 +183,34 @@ const convertItemToPushFormat = (travel) => {
   return newTravel;
 };
 
+const errorMessage = (err) => {
+  let errMsg = '';
+  const { response } = err;
+  if (response.status === 400) {
+    const { head } = response.data;
+    const { title } = head;
+    const { tags } = head;
+    errMsg += title ? '- Fill in the title\n' : '';
+    errMsg += tags ? '- Add at least one tag\n' : '';
+
+    if (head.days) {
+      // eslint-disable-next-line array-callback-return
+      head.days.map((day, i) => {
+        if (day.blocks) {
+          // eslint-disable-next-line array-callback-return
+          day.blocks.map((block, j) => {
+            errMsg += block.title ? `- Fill in the title of Day ${i + 1} Block ${j + 1}\n` : '';
+            errMsg += block.start_location ? `- Fill in the start location of Day ${i + 1} Block ${j + 1}\n` : '';
+          });
+        }
+      });
+    }
+  } else {
+    errMsg = response.data;
+  }
+  return errMsg;
+};
+
 export const createTravel = (travel, form_data) => {
   return (dispatch) => {
     const newTravel = convertItemToPushFormat(travel);
@@ -209,11 +237,14 @@ export const createTravel = (travel, form_data) => {
         },
       ).catch(
         (err) => {
-          dispatch(push('/error'));
+          const message = errorMessage(err);
+          console.log(message);
+          alert(message);
         },
       );
   };
 };
+
 
 export const editTravel = (id, travel) => {
   return (dispatch) => {


### PR DESCRIPTION
create travel이 실패했을 때
기존에 error 페이지로 넘어가던 부분을
error message를 alert하는 방식으로 변경하였습니다.

- 400 error
필수로 채워야 하는 field들이 채워지지 않은 경우에
form check 결과를 alert 메시지에 포함하도록 했습니다.
- 그 외 error
backend error 메시지 그대로 alert